### PR TITLE
chore: bump TypeScript to 6 and pnpm/action-setup to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.3] - 2026-04-29
+
+### Changed
+
+- Bump typescript from 5.9.3 to 6.0.3
+- Bump pnpm/action-setup from 5 to 6
+- Bump pnpm (packageManager) from 10.26.2 to 10.33.2
+
 ## [2.1.2] - 2026-04-29
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxlint-plugin-complexity",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Cyclomatic and cognitive complexity rules for oxlint",
   "keywords": [
     "oxlint",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "oxlint": "^1.62.0",
     "prettier": "3.8.3",
     "tsx": "^4.21.0",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.5"
   },
   "peerDependencies": {
@@ -90,5 +90,5 @@
   "engines": {
     "node": ">=20.0.0"
   },
-  "packageManager": "pnpm@10.26.2"
+  "packageManager": "pnpm@10.33.2"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^4.21.0
         version: 4.21.0
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@types/node@22.19.17)(vite@7.3.1(@types/node@22.19.17)(tsx@4.21.0))
@@ -931,8 +931,8 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -1687,7 +1687,7 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
   undici-types@6.21.0: {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "lib": ["ES2023"],
+    "types": ["node"],
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,
@@ -14,11 +15,7 @@
     "declarationMap": true,
     "sourceMap": true,
     "resolveJsonModule": true,
-    "isolatedModules": true,
-    "paths": {
-      "#src/*": ["./src/*"]
-    },
-    "baseUrl": "."
+    "isolatedModules": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "**/*.test.ts"]


### PR DESCRIPTION
## Summary

Picks up the two deferred dependabot upgrades (#87, #77) with the small migrations they need. Supersedes #87 and #77.

### TypeScript 5.9.3 → 6.0.3 (#87)
- Drop `baseUrl` from `tsconfig.json` (TS 6 deprecates it; would error without `"ignoreDeprecations": "6.0"`).
- Drop `paths` too — it was unused inside `src/` (compile target). Tests still resolve `#src/*` via `vitest.config.ts`'s own `resolve.alias` + `esbuild.tsconfigRaw.paths`, plus the `imports` field in `package.json` for runtime ESM. None of those depend on tsconfig `paths`.
- Add `"types": ["node"]` — TS 6 no longer auto-discovers `@types/node` for this config (the failure was `error TS2591: Cannot find name 'node:fs'` in `src/diff.ts`).

### pnpm/action-setup v5 → v6 (#77)
- Bump `pnpm/action-setup@v5` → `@v6` in both `ci.yml` and `release.yml`.
- Bump `packageManager` to `pnpm@10.33.2` (latest 10.x). v6 of the action supports pnpm 11 but doesn't require it; we stay on pnpm 10 because pnpm 11.0.0 is still pre-`latest` on npm. Lockfile diff is empty — pnpm 10.x is forward-compatible across patch/minor.

## Test plan
- [x] `corepack pnpm install --frozen-lockfile` (clean)
- [x] `pnpm format:check`
- [x] `pnpm exec tsc --noEmit` (TypeScript 6.0.3)
- [x] `pnpm build`
- [x] `pnpm exec oxlint src/` (0 warnings, 0 errors)
- [x] `pnpm test:run` (579/579 passed)
- [ ] CI green