### PR TITLE
chore: consolidate 2.1.3 changelog into 2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.1.3] - 2026-04-29
-
-### Changed
-
-- Bump typescript from 5.9.3 to 6.0.3
-- Bump pnpm/action-setup from 5 to 6
-- Bump pnpm (packageManager) from 10.26.2 to 10.33.2
-
 ## [2.1.2] - 2026-04-29
 
 ### Changed
@@ -24,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump prettier from 3.8.1 to 3.8.3
 - Bump diff from 8.0.4 to 9.0.0
 - Bump @types/node from 22.19.15 to 22.19.17
+- Bump typescript from 5.9.3 to 6.0.3
+- Bump pnpm/action-setup from 5 to 6
+- Bump pnpm (packageManager) from 10.26.2 to 10.33.2
 
 ## [2.1.1] - 2026-04-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,7 +180,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Actions CI pipeline
 - Pre-commit hooks with Husky
 
-[Unreleased]: https://github.com/itaymendel/oxlint-plugin-complexity/compare/v2.1.1...HEAD
+[Unreleased]: https://github.com/itaymendel/oxlint-plugin-complexity/compare/v2.1.2...HEAD
+[2.1.2]: https://github.com/itaymendel/oxlint-plugin-complexity/compare/v2.1.1...v2.1.2
 [2.1.1]: https://github.com/itaymendel/oxlint-plugin-complexity/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/itaymendel/oxlint-plugin-complexity/compare/v2.0.3...v2.1.0
 [2.0.3]: https://github.com/itaymendel/oxlint-plugin-complexity/compare/v2.0.2...v2.0.3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxlint-plugin-complexity",
-  "version": "2.1.3",
+  "version": "2.1.2",
   "description": "Cyclomatic and cognitive complexity rules for oxlint",
   "keywords": [
     "oxlint",


### PR DESCRIPTION
## Summary

2.1.2 was never published to npm; the work that landed under a separate 2.1.3 entry will ship together as a single 2.1.2 release. Collapse the two entries and revert `package.json` version to 2.1.2.

### Changes
- CHANGELOG: merge the 2.1.3 entry's three lines into the existing 2.1.2 entry (typescript 6, pnpm/action-setup v6, pnpm 10.33.2).
- `package.json`: version 2.1.3 → 2.1.2.
- No code or lockfile changes.

## Test plan
- [x] `pnpm test:run` (579/579 passed via pre-commit hook)
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Package version downgraded to 2.1.2.

* **Documentation**
  * Updated changelog to consolidate dependency updates for version 2.1.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->