### PR TITLE
fix: move @oxlint/plugins from peerDependency to dependency (#102)

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,8 +57,10 @@
     "prepublishOnly": "pnpm run build",
     "prepare": "husky"
   },
+  "dependencies": {
+    "@oxlint/plugins": "^1.62.0"
+  },
   "devDependencies": {
-    "@oxlint/plugins": "^1.62.0",
     "@types/node": "^22.19.17",
     "diff": "^9.0.0",
     "estree-walker": "^3.0.3",
@@ -71,7 +73,6 @@
     "vitest": "^4.1.5"
   },
   "peerDependencies": {
-    "@oxlint/plugins": ">=1.43.0",
     "diff": ">=5.0.0",
     "estree-walker": ">=3.0.0",
     "oxc-parser": ">=0.60.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,11 @@ settings:
 importers:
 
   .:
-    devDependencies:
+    dependencies:
       '@oxlint/plugins':
         specifier: ^1.62.0
         version: 1.62.0
+    devDependencies:
       '@types/node':
         specifier: ^22.19.17
         version: 22.19.19


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * `@oxlint/plugins` is now a runtime dependency, automatically included with installation
  * Peer dependencies streamlined to `diff`, `estree-walker`, and `oxc-parser` only, reducing setup complexity

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/itaymendel/oxlint-plugin-complexity/pull/107?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->