### PR TITLE
chore: release v2.1.4 and add npm publish automation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,86 @@
+name: Publish
+
+# Publishes the package to npm when a version tag (vX.Y.Z) is pushed.
+# Auth uses npm trusted publishing (OIDC) — no NPM_TOKEN secret required.
+# Configure the trusted publisher once at:
+#   https://www.npmjs.com/package/oxlint-plugin-complexity/access
+#   -> Trusted Publishers -> GitHub Actions
+#   repo: itaymendel/oxlint-plugin-complexity, workflow: publish.yml
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write # OIDC token for npm trusted publishing + provenance
+      contents: write # create the GitHub Release
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check formatting
+        run: pnpm format:check
+
+      - name: Check types
+        run: pnpm exec tsc --noEmit
+
+      - name: Lint
+        run: pnpm run lint
+
+      - name: Run tests
+        run: pnpm test:run
+
+      - name: Build
+        run: pnpm build
+
+      - name: Verify tag matches package.json version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          echo "Tag: $TAG_VERSION  package.json: $PKG_VERSION"
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag v$TAG_VERSION does not match package.json version $PKG_VERSION"
+            exit 1
+          fi
+
+      - name: Upgrade npm for trusted publishing
+        # Trusted publishing (OIDC) requires npm >= 11.5.1; Node 22 ships with npm 10.x.
+        run: npm install -g npm@latest
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          # Extract this version's section from CHANGELOG.md (between its heading and the next).
+          NOTES="$(awk -v v="$VERSION" '
+            $0 ~ "^## \\[" v "\\]" { flag=1; next }
+            /^## \[/ { flag=0 }
+            flag { print }
+          ' CHANGELOG.md)"
+          if [ -z "$NOTES" ]; then
+            NOTES="Release $GITHUB_REF_NAME"
+          fi
+          gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --notes "$NOTES"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.4] - 2026-06-12
+
+### Changed
+
+- Bump @oxlint/plugins from 1.66.0 to 1.69.0 (#118)
+- Bump oxlint from 1.66.0 to 1.69.0 (#119)
+- Bump oxc-parser from 0.132.0 to 0.135.0 (#116)
+- Bump @types/node from 22.19.19 to 22.19.20 (#117)
+- Bump tsx from 4.22.3 to 4.22.4 (#114)
+- Bump vitest from 4.1.7 to 4.1.8 (#112)
+
+### Internal
+
+- Add npm publish workflow: pushing a `vX.Y.Z` tag publishes to npm via trusted publishing (OIDC) with provenance and creates a GitHub Release
+
 ## [2.1.3] - 2026-05-24
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxlint-plugin-complexity",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Cyclomatic and cognitive complexity rules for oxlint",
   "keywords": [
     "oxlint",


### PR DESCRIPTION
## Release v2.1.4

Ships the batched dependency updates from #120 (no API changes — patch release).

- Bump version `2.1.3` → `2.1.4`
- CHANGELOG entry for 2.1.4

## New: npm publish automation

Adds `.github/workflows/publish.yml`. On pushing a `vX.Y.Z` tag it:
1. Runs the full CI suite (format, types, lint, 579 tests, build)
2. Verifies the tag matches `package.json` version
3. Publishes to npm via **trusted publishing (OIDC)** with **provenance** — no `NPM_TOKEN` secret
4. Creates a GitHub Release from the matching CHANGELOG section

### After merge
Tag the merge commit `v2.1.4` and push the tag to trigger the publish. Trusted publisher must be configured on the npm package settings (repo `itaymendel/oxlint-plugin-complexity`, workflow `publish.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)