### PR TITLE
fix(ci): use OIDC for npm trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,8 +31,10 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
-          registry-url: 'https://registry.npmjs.org'
           cache: pnpm
+          # No registry-url / NODE_AUTH_TOKEN on purpose: a configured token
+          # shadows OIDC. Trusted publishing only activates when no auth token
+          # is set, so npm falls through to the OIDC token exchange.
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
The v2.1.4 publish run failed with a 404 on `npm publish`. Root cause: `setup-node` + `registry-url` writes an `.npmrc` token line and sets `NODE_AUTH_TOKEN` to a placeholder, which shadows OIDC. Trusted publishing only activates when no auth token is configured.

Fix: drop `registry-url` from the Setup Node step so npm falls through to the OIDC token exchange. Provenance signing already worked in the failed run, confirming the OIDC token is available.

After merge: re-point the `v2.1.4` tag at the fixed commit and re-push to retry the publish (nothing was published, so the version is clean to reuse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the package publishing workflow security by implementing enhanced authentication methods. All validation steps including dependency installation, code formatting, type checking, linting, and comprehensive testing remain unchanged, ensuring reliable and secure package releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->