### PR TITLE
fix(ci): unset placeholder NODE_AUTH_TOKEN so npm uses OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,7 +75,14 @@ jobs:
           node -e 'const [a,b,c]=process.argv[1].split(".").map(Number); if (a<11 || (a===11 && (b<5 || (b===5 && c<1)))) { console.error("npm >= 11.5.1 required for trusted publishing, got "+process.argv[1]); process.exit(1); }' "$NPM_VER"
 
       - name: Publish to npm
-        run: npm publish --provenance --access public
+        run: |
+          # setup-node (with registry-url) exports a placeholder NODE_AUTH_TOKEN
+          # and writes `_authToken=${NODE_AUTH_TOKEN}` into .npmrc. That bogus
+          # token shadows OIDC, so npm tries token auth and gets a 404. Unset it
+          # so the token resolves empty and npm uses the OIDC trusted-publishing
+          # exchange instead.
+          unset NODE_AUTH_TOKEN
+          npm publish --provenance --access public
 
       - name: Create GitHub Release
         env:


### PR DESCRIPTION
Third and (hopefully) final auth fix. With `registry-url` set, `setup-node` exports a placeholder `NODE_AUTH_TOKEN=XXXXX-...` and writes `_authToken=${NODE_AUTH_TOKEN}` into `.npmrc`. On npm 11.17 the publish step authenticated with that bogus token → 404, never engaging OIDC (provenance still signed, since it uses the id-token directly).

Fix: `unset NODE_AUTH_TOKEN` before `npm publish` so the token resolves empty and npm performs the OIDC trusted-publishing exchange — the documented "registry-url set, no token, npm >= 11.5.1" state.

If this still 404s, the cause is a trusted-publisher config mismatch on the npm package settings (org `itaymendel`, repo `oxlint-plugin-complexity`, workflow `publish.yml`, no environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)